### PR TITLE
Options hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,29 @@ filterByQuery( guy.get('friends'), ['name','surname'], controller.get('query'));
 
 Notice that in this case, the first and last argument can't be property keys anymore but have to be the actuall array and query.
 
+## additional Options
+
+It is possible to pass a set of different options to the computed property macro aswell as to the utility function.
+
+| Option        | Type | Description  |
+| ------------- |:-----|:------|
+| filter        | boolean | If false, items with a score of zero will not be filtered out of the result-set. |
+| conjunction   | string  | Determines how multiple search terms are joined ("and" or "or"). |
+
+```javascript
+import computedFilterByQuery from 'ember-cli-filter-by-query';
+
+Guy = DS.Model.extend({
+
+  smallList: computedFilterByQuery( 'friends', ['name', 'surname'], 'query', {conjunction: 'and' })
+  // this will only list friends whos name or surname include every word in the query
+
+  largeList: computedFilterByQuery( 'friends', ['name', 'surname'], 'query', {conjunction: 'or' })
+  // this will list friends whos name or surname include at least one word of the query
+
+});
+```
+
 ## Installation
 
 To use this addon in your project, just type:

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import filterByQuery from 'ember-cli-filter-by-query/util/filter';
 
-var computedFilterByQuery = function(dependentKey, propertyKeys, queryKey) {
+var computedFilterByQuery = function(dependentKey, propertyKeys, queryKey, options) {
   propertyKeys = Ember.makeArray(propertyKeys);
 
   return Ember.computed( queryKey, '' + dependentKey + '.@each.{' + propertyKeys.join(',') + '}', function() {
@@ -9,7 +9,7 @@ var computedFilterByQuery = function(dependentKey, propertyKeys, queryKey) {
     var array = Ember.makeArray(this.get(dependentKey));
     var query = this.get(queryKey) || '';
 
-    return filterByQuery(array, propertyKeys, query);
+    return filterByQuery(array, propertyKeys, query, options);
 
   });
 };

--- a/addon/util/filter.js
+++ b/addon/util/filter.js
@@ -1,7 +1,8 @@
 import Ember from 'ember';
 /*global Sifter*/
 
-var filterByQuery = function(array, propertyKeys, query) {
+var filterByQuery = function(array, propertyKeys, query, options) {
+  options = Ember.typeOf(options) === 'undefined' ? {} : options;
   propertyKeys = Ember.makeArray(propertyKeys);
   var input, sifter, result;
 
@@ -13,13 +14,14 @@ var filterByQuery = function(array, propertyKeys, query) {
     return hash;
   });
 
-  sifter = new Sifter(input);
-
-  result = sifter.search(query, {
-    fields: propertyKeys,
-    sort: propertyKeys.map(function(key) {return {field: key, direction: 'asc'};}),
-    limit: array.length
+  options.fields = options.fields || propertyKeys;
+  options.limit = options.limit || array.length;
+  options.sort = propertyKeys.map(function(key) {
+    return {field: key, direction: 'asc'};
   });
+
+  sifter = new Sifter(input);
+  result = sifter.search(query, options);
 
   return result.items.map( function(item) {
     return array[item.id];

--- a/tests/unit/filter-by-query-test.js
+++ b/tests/unit/filter-by-query-test.js
@@ -6,7 +6,7 @@ var array;
 
 module('utility function test');
 
-test('it returns an array', function(assert) {
+test('filters with "or" conjunction', function(assert) {
   var input, output;
   assert.expect(1);
 
@@ -16,8 +16,22 @@ test('it returns an array', function(assert) {
     {id: 3, foo: 'prsss', bar: 'aa'},
   ];
 
-  output = filterByQuery(input, ['foo','bar'], 'po');
-  assert.deepEqual(output, [input[0], input[1]]);
+  output = filterByQuery(input, ['foo','bar'], 'po aa', {conjunction: 'or'});
+  assert.deepEqual(output, [input[1], input[2], input[0]]);
 
+});
+
+test('filters with "and" conjunction', function(assert) {
+  var input, output;
+  assert.expect(1);
+
+  input = [
+    {id: 1, foo: 'psopao', bar: 'opoko' },
+    {id: 2, foo: 'aapoko', bar: 'aaa'},
+    {id: 3, foo: 'prsss', bar: 'aa'},
+  ];
+
+  output = filterByQuery(input, ['foo','bar'], 'po aa', {conjunction: 'and'});
+  assert.deepEqual(output, [input[1]]);
 
 });


### PR DESCRIPTION
Supports options you can pass through to sifter to specify the conjunction approach (`and` or `or`) and a filter boolean that allows you to only sort the list but never actually filter it.

addresses #1 
