### PR TITLE
Don't set options.limit to array.length

### DIFF
--- a/addon/util/filter.js
+++ b/addon/util/filter.js
@@ -24,7 +24,6 @@ var filterByQuery = function(array, propertyKeys, query, options) {
   });
 
   options.fields = options.fields || propertyKeys;
-  options.limit = options.limit || array.length;
   if (sort) {
     options.sort = propertyKeys.map(function(key) {
       return {field: key, direction: 'asc'};


### PR DESCRIPTION
This can hardcode the limit with a previous array length, which will keep that limit even if the array grows later on.
Sifter does not require a limit property, so just delete it here and pass it optionally.